### PR TITLE
Force acyclic input

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ assert poset.compare(2, 3) == '||'
 poset2 = poset.add([2, 1])
 poset2.compare(1, 2) == '='
 ```
+PoSet must be a DAG.  For large posets we encourage batching via from_chains over many small add() calls.

--- a/hasse/poset.py
+++ b/hasse/poset.py
@@ -20,6 +20,10 @@ class PoSet:
    """
    hasse: nx.DiGraph = attr.ib(factory=nx.DiGraph)
 
+   def __attrs_post_init__(self) -> None:
+       if not nx.is_directed_acyclic_graph(self.hasse):
+           raise ValueError("PoSet must be a DAG (directed acyclic graph)")   
+   
    def __len__(self) -> int:
        return len(self.hasse)
 

--- a/hasse/poset.py
+++ b/hasse/poset.py
@@ -41,6 +41,8 @@ class PoSet:
    def add(self, chain: Chain) -> PoSet:
        hasse = nx.DiGraph(self.hasse)
        nx.add_path(hasse, chain)
+       if not nx.is_directed_acyclic_graph(hasse):
+           raise ValueError(f"Adding chain {chain} introduces a cycle")
        return attr.evolve(self, hasse=nx.transitive_reduction(hasse))
 
    @staticmethod
@@ -48,4 +50,6 @@ class PoSet:
        hasse = nx.DiGraph()
        for chain in chains:
            nx.add_path(hasse, chain)
+       if not nx.is_directed_acyclic_graph(hasse):
+            raise ValueError(f"Chains {chains} introduce a cycle")
        return PoSet(nx.transitive_reduction(hasse))

--- a/hasse/poset.py
+++ b/hasse/poset.py
@@ -45,8 +45,6 @@ class PoSet:
    def add(self, chain: Chain) -> PoSet:
        hasse = nx.DiGraph(self.hasse)
        nx.add_path(hasse, chain)
-       if not nx.is_directed_acyclic_graph(hasse):
-           raise ValueError(f"Adding chain {chain} introduces a cycle")
        return attr.evolve(self, hasse=nx.transitive_reduction(hasse))
 
    @staticmethod
@@ -54,6 +52,4 @@ class PoSet:
        hasse = nx.DiGraph()
        for chain in chains:
            nx.add_path(hasse, chain)
-       if not nx.is_directed_acyclic_graph(hasse):
-            raise ValueError(f"Chains {chains} introduce a cycle")
        return PoSet(nx.transitive_reduction(hasse))

--- a/hasse/poset.py
+++ b/hasse/poset.py
@@ -25,8 +25,11 @@ class PoSet:
        #H = nx.DiGraph()
        #H.add_edges_from([(0, 1), (1, 0)])  # cycle
        #P = hasse.PoSet(H)
-       if not nx.is_directed_acyclic_graph(self.hasse):
-           raise ValueError("PoSet must be a DAG (directed acyclic graph)")   
+       try:
+           reduced = nx.transitive_reduction(self.hasse)
+       except nx.NetworkXError:
+           raise ValueError("PoSet must be a DAG (directed acyclic graph)")
+       object.__setattr__(self, "hasse", reduced)
           
    
    def __len__(self) -> int:
@@ -50,11 +53,11 @@ class PoSet:
    def add(self, chain: Chain) -> PoSet:
        hasse = nx.DiGraph(self.hasse)
        nx.add_path(hasse, chain)
-       return attr.evolve(self, hasse=nx.transitive_reduction(hasse))
+       return attr.evolve(self, hasse=hasse)
 
    @staticmethod
    def from_chains(*chains: list[Chain]) -> PoSet:
        hasse = nx.DiGraph()
        for chain in chains:
            nx.add_path(hasse, chain)
-       return PoSet(nx.transitive_reduction(hasse))
+       return PoSet(hasse)

--- a/hasse/poset.py
+++ b/hasse/poset.py
@@ -21,8 +21,13 @@ class PoSet:
    hasse: nx.DiGraph = attr.ib(factory=nx.DiGraph)
 
    def __attrs_post_init__(self) -> None:
+       #added to prevent
+       #H = nx.DiGraph()
+       #H.add_edges_from([(0, 1), (1, 0)])  # cycle
+       #P = hasse.PoSet(H)
        if not nx.is_directed_acyclic_graph(self.hasse):
            raise ValueError("PoSet must be a DAG (directed acyclic graph)")   
+          
    
    def __len__(self) -> int:
        return len(self.hasse)


### PR DESCRIPTION
The case below was previously not detected. We now verify acyclic input during construction.
`
H = nx.DiGraph()

H.add_edges_from([(0, 1), (1, 0)])  # cycle

P = hasse.PoSet(H) `

Note that this patch does not remove redundant edges as requested  in https://github.com/mvcisback/hasse/issues/1, that change may be submitted independently. 